### PR TITLE
docs(cn): fix React.startTransition translation error

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -386,8 +386,8 @@ React.startTransition(callback)
 
 > 注意：
 >
-> 过渡期的更新会产生更紧急的更新，如点击操作。
+> 过渡期的更新会被更紧急的更新取代，如点击操作。
 >
-> 转成中的更新不会显示重新挂起内容的 fallback，允许用户在渲染更新时继续进行交互。
+> 过渡期的更新不会显示重新挂起内容的 fallback，允许用户在渲染更新时继续进行交互。
 >
 > `React.startTransition` 不提供 `isPending` 的标志。要跟踪过渡的待定状态，请参阅 [`React.useTransition`](/docs/hooks-reference.html#usetransition)。


### PR DESCRIPTION
`yield to sth` 主要有两个意思：

- If you yield to someone or something, you stop resisting them.
- if one thing yields to another, it is replaced by that thing.

中文意思大概就是屈服于、让步于、让位于。
参见 [collinsdictionary](https://www.collinsdictionary.com/dictionary/english/yield)

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
